### PR TITLE
Bugfix for load of fastai v1 trained model

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8]
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:

--- a/convml_tt/data/examples.py
+++ b/convml_tt/data/examples.py
@@ -56,6 +56,22 @@ def fetch_pretrained_model(pretrained_model: PretrainedModel, data_dir="data/"):
     return _fetch_example(item=pretrained_model, data_dir=data_dir) / fname
 
 
+def load_pretrained_model(pretrained_model: PretrainedModel, data_dir="data/"):
+    """
+    Downloads pretrained model and returns the path to it
+    """
+    model_path = fetch_pretrained_model(
+        pretrained_model=pretrained_model, data_dir=data_dir
+    )
+    if pretrained_model == PretrainedModel.FIXED_NORM_STAGE2:
+        from ..external import fastai1_weights_loader
+
+        model = fastai1_weights_loader.model_from_saved_weights(path=model_path)
+    else:
+        raise NotImplementedError(pretrained_model)
+    return model
+
+
 def main(args=None):
     """
     CLI interface for downloading data examples

--- a/convml_tt/external/fastai1_weights_loader.py
+++ b/convml_tt/external/fastai1_weights_loader.py
@@ -7,6 +7,15 @@ from .nn_layers import AdaptiveConcatPool2d
 from ..system import TripletTrainerModel
 
 
+class ScalingLayer(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.scale = scale
+
+    def forward(self, x):
+        return x * self.scale
+
+
 def model_from_saved_weights(path):
     """
     This routine is only here so that models which were trained with
@@ -26,15 +35,37 @@ def model_from_saved_weights(path):
 
     # before we can run the model we need to add the adaptive-pooling layer and
     # the flattening layer in again because these couldn't be pickled (they
-    # weren't part of pytorch 1.0.1 that the old model was created in)
+    # weren't part of pytorch 1.0.1 that the old model was created in). We also
+    # introduce a scaling layer because the fastai v1 network created values
+    # that we're very small
     head = loaded_encoder[-1]
-    new_head = nn.Sequential(AdaptiveConcatPool2d(size=1), nn.Flatten(), *head)
-    loaded_encoder = nn.Sequential(*loaded_encoder[:-1], new_head)
+    new_head = nn.Sequential(
+        AdaptiveConcatPool2d(size=1), nn.Flatten(), *head, ScalingLayer(1.0e3)
+    )
+    # we use the backbone as-is
+    backbone = loaded_encoder[:-1]
 
     rand_batch = torch.rand((batch_size, n_input_channels, nx, ny))
     try:
         # check that the model accepts data shaped like a batch and produces the expected output
-        result_batch = loaded_encoder(rand_batch)
+        # all we know is the weights, so this model won't be possible to train further
+        model = TripletTrainerModel(
+            base_arch="unknown",
+            margin="unknown",
+            lr="unknown",
+            l2_regularisation="unknown",
+        )
+        # when passing in `base_arch="unknown"` above the backbone and head
+        # won't be set on the model and we can set them directly here
+        model.backbone = backbone
+        model.head = new_head
+        # we finally set the `base_arch` attribute manually as this is used for
+        # working out the image normalization transform
+        model.base_arch = "resnet18"
+        # finally we set a flag which ensure the output is scaled by 1.0e3 (for some reason the model I trained
+        setattr(model, "from_fastai_v1", True)
+
+        result_batch = model.forward(rand_batch)
         n_embedding_dims = result_batch.shape[-1]
         expected_shape = (batch_size, n_embedding_dims)
         if result_batch.shape != expected_shape:
@@ -42,14 +73,6 @@ def model_from_saved_weights(path):
                 "The shape of the output of the loaded encoder doesn't have "
                 f"the expected shape, {result_batch.shape} != {expected_shape}"
             )
-        # all we know is the weights, so this model won't be possible to train further
-        model = TripletTrainerModel(
-            base_arch="resnet18",
-            margin="unknown",
-            lr="unknown",
-            l2_regularisation="unknown",
-        )
-        model.encoder = loaded_encoder
         print(f"Weights loaded from `{path}`")
         return model
     except Exception as e:  # noqa

--- a/convml_tt/utils.py
+++ b/convml_tt/utils.py
@@ -25,13 +25,6 @@ def get_embeddings(tile_dataset: ImageSingletDataset, model, prediction_batch_si
         batched_results.append(y_batch.cpu().detach().numpy())
 
     embeddings = np.vstack(batched_results)
-    if model.base_arch == "unknown":
-        # XXX: the models I trained with fastai as the backend have really
-        # small magnitude in the embedding values. So I'll scale the values
-        # here. Remove this once we've stopped using the old fastai trained
-        # models
-        embeddings *= 1.0e3
-
     tile_ids = np.arange(len(tile_dataloader.dataset))
 
     dims = ("tile_id", "emb_dim")

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,4 +1,6 @@
 import pytorch_lightning as pl
+import numpy as np
+import torch
 
 from convml_tt.system import (
     TripletTrainerModel,
@@ -9,12 +11,11 @@ from convml_tt.data.examples import (
     fetch_example_dataset,
     ExampleData,
     PretrainedModel,
-    fetch_pretrained_model,
+    load_pretrained_model,
 )
 from convml_tt.data.dataset import TileType, ImageSingletDataset
 from convml_tt.data.transforms import get_transforms
 from convml_tt.utils import get_embeddings
-from convml_tt.external import fastai1_weights_loader
 
 
 def test_train_new():
@@ -50,11 +51,29 @@ def test_finetune_pretrained():
     trainer.fit(model=model, datamodule=datamodule)
 
 
+def assert_models_equal(model_1, model_2):
+    differences = {}
+    for (k1, v1), (k2, v2) in zip(
+        model_1.state_dict().items(), model_2.state_dict().items()
+    ):
+        if torch.equal(v1, v2):
+            pass
+        else:
+            if k1 == k2:
+                differences[k1] = (v1, v2)
+            else:
+                raise Exception
+
+    if len(differences) > 0:
+        msg = (
+            f"There were differences found in {len(differences)} out of "
+            f"{len(model_1.state_dict())} layers: " + ", ".join(differences.keys())
+        )
+        raise Exception(msg)
+
+
 def test_load_from_weights():
-    model_path = fetch_pretrained_model(
-        pretrained_model=PretrainedModel.FIXED_NORM_STAGE2
-    )
-    model = fastai1_weights_loader.model_from_saved_weights(path=model_path)
+    model = load_pretrained_model(pretrained_model=PretrainedModel.FIXED_NORM_STAGE2)
 
     data_path = fetch_example_dataset(dataset=ExampleData.TINY10)
     dataset = ImageSingletDataset(
@@ -63,4 +82,23 @@ def test_load_from_weights():
         tile_type=TileType.ANCHOR,
         transform=get_transforms(step="predict", normalize_for_arch=model.base_arch),
     )
-    get_embeddings(tile_dataset=dataset, model=model, prediction_batch_size=16)
+    da_emb = get_embeddings(tile_dataset=dataset, model=model, prediction_batch_size=16)
+
+    # there was a bug where fetching, loading and producing embeddings the same
+    # way again yielded different embeddings. I need to check that using a
+    # loaded network always gives the same result
+    model2 = load_pretrained_model(pretrained_model=PretrainedModel.FIXED_NORM_STAGE2)
+
+    def has_same_parameters(model1, model2):
+        for p1, p2 in zip(model1.parameters(), model2.parameters()):
+            if p1.data.ne(p2.data).sum() > 0:
+                return False
+        return True
+
+    assert_models_equal(model, model2)
+
+    da_emb2 = get_embeddings(
+        tile_dataset=dataset, model=model2, prediction_batch_size=20
+    )
+
+    np.testing.assert_allclose(da_emb, da_emb2)


### PR DESCRIPTION
Fix bug where `backbone` and `head` of resulting `TripletTrainerModel`
weren't correctly set leading to the predictions of the resulting model
to change every time the model was loaded anew. Also adds convenience
function for fetching and loading pretrained triplettrainer models with
one fuction.