### PR TITLE
set minimum version for torchvision

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     jupyter
     scikit-image
     antialiased-cnns >= 0.3
+    torchvision >= 0.4.0
 setup_requires =
     setuptools >= 40.4
     setuptools_scm


### PR DESCRIPTION
torchvision's download_and_extract function wasn't added until v0.4.0