### PR TITLE
Bugfix for grid-overview plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   finder](https://pytorch-lightning.readthedocs.io/en/latest/advanced/lr_finder.html))
   [\#30](https://github.com/convml/convml_tt/pull/30)
 
+*bugfixes*
+
+- Fix for grid-overview plot always showing same set of tiles rather than tiles with indecies provided [\#36](https://github.com/convml/convml_tt/pull/36)
+
 ## [v0.8.0](https://github.com/convml/convml_tt/tree/v0.8.0)
 
 [Full Changelog](https://github.com/convml/convml_tt/compare/v0.7.1...v0.8.0)

--- a/convml_tt/interpretation/plots/grid_overview.py
+++ b/convml_tt/interpretation/plots/grid_overview.py
@@ -46,9 +46,9 @@ def grid_overview(
         ax = axes.flatten()[n]
         ax.axison = False
         if isinstance(tile_dataset, ImageTripletDataset):
-            tile_image = tile_dataset.get_image(index=n, tile_type=tile_type)
+            tile_image = tile_dataset.get_image(index=i, tile_type=tile_type)
         elif isinstance(tile_dataset, ImageSingletDataset):
-            tile_image = tile_dataset.get_image(index=n)
+            tile_image = tile_dataset.get_image(index=i)
         else:
             raise NotImplementedError(tile_dataset)
 


### PR DESCRIPTION
Previously the "grid overview" plot always showed the same first N
example tiles rather than the tiles with indecies provided