### PR TITLE
dendrogram plotting in single figure

### DIFF
--- a/convml_tt/interpretation/plots/dendrogram.py
+++ b/convml_tt/interpretation/plots/dendrogram.py
@@ -280,7 +280,6 @@ def dendrogram(
     # the x-positions match the cluster indecies (0, 1, ... n_max_clusters-1)
     # we can then join this with the axes below where we will render the tiles
     # and the x-positioning becomes much easier
-    ax_tiles.set_aspect(1.0)
     secax = ax_dendrogram.secondary_xaxis(
         "bottom", functions=(xposn2clusterid, clusterid2xposn)
     )

--- a/convml_tt/interpretation/plots/dendrogram.py
+++ b/convml_tt/interpretation/plots/dendrogram.py
@@ -1,24 +1,18 @@
 #!/usr/bin/env python
 # coding: utf-8
-from tqdm import tqdm
 import matplotlib.pyplot as plt
 import numpy as np
 
-import sklearn.decomposition
-from sklearn.preprocessing import StandardScaler
 from scipy.cluster import hierarchy as hc
 
 from ...data.dataset import ImageSingletDataset, TileType, ImageTripletDataset
-
-
-# In[13]:
 
 
 def _make_letter_labels(n_labels):
     return np.array([chr(i + 97).upper() for i in np.arange(n_labels)])
 
 
-def _fix_labels(ax, leaf_mapping, label_clusters=False):
+def _fix_labels(ax, tile_idxs_per_cluster, label_clusters=False):
     """
     Initially the labels simply correspond the leaf index, but we want to plot
     the number of items that belong to that leaf. And optionally give each leaf
@@ -26,9 +20,10 @@ def _fix_labels(ax, leaf_mapping, label_clusters=False):
     """
     new_labels = []
 
-    for (i, label) in enumerate(ax.get_xticklabels()):
-        leaf_index = int(label.get_text())
-        num_items_in_leaf = np.sum(leaf_index == leaf_mapping)
+    for (i, cluster_label) in enumerate(ax.get_xticklabels()):
+        cluster_id = int(cluster_label.get_text())
+        items_cluster = tile_idxs_per_cluster[cluster_id]
+        num_items_in_leaf = len(items_cluster)
         new_label = str(num_items_in_leaf)
         if label_clusters:
             new_label += "\n{}".format(chr(i + 97).upper())
@@ -49,13 +44,101 @@ def _get_tile_image(tile_dataset, i, tile_type):
     return tile_image
 
 
+def _find_tile_indecies(
+    img_idxs_in_cluster, n_samples, sampling_method, da_clustering, da_embeddings
+):
+    if sampling_method == "random":
+        try:
+            img_idxs = np.random.choice(
+                img_idxs_in_cluster, size=n_samples, replace=False
+            )
+        except ValueError:
+            img_idxs = img_idxs_in_cluster
+    elif sampling_method == "center_dist":
+        emb_in_cluster = da_clustering.sel(tile_id=img_idxs_in_cluster)
+        d_emb = emb_in_cluster.mean(dim="tile_id") - emb_in_cluster
+        center_dist = np.sqrt(d_emb ** 2.0).sum(dim="emb_dim")
+        emb_in_cluster["dist_to_center"] = center_dist
+        img_idxs = emb_in_cluster.sortby("dist_to_center").tile_id.values[:n_samples]
+    elif sampling_method in ["best_triplets", "worst_triplets"]:
+        if "tile_type" not in da_embeddings.coords:
+            raise Exception(
+                "Selection method based on triplets can only be used when"
+                " passing in embeddings for triplets"
+            )
+        da_emb_in_cluster = da_embeddings.sel(tile_id=img_idxs_in_cluster)
+        da_emb_dist = da_emb_in_cluster.sel(tile_type="anchor") - da_emb_in_cluster.sel(
+            tile_type="neighbor"
+        )
+        near_dist = np.sqrt(da_emb_dist ** 2.0).sum(dim="emb_dim")
+        da_emb_in_cluster["near_dist"] = near_dist
+        img_idxs_all = da_emb_in_cluster.sortby("near_dist").tile_id.values
+        if sampling_method == "best_triplets":
+            img_idxs = img_idxs_all[:n_samples]
+        else:
+            img_idxs = img_idxs_all[::-1][:n_samples]
+    elif sampling_method == "worst_triplets":
+        da_emb_in_cluster = da_embeddings.sel(tile_id=img_idxs_in_cluster)
+        da_emb_dist = da_emb_in_cluster.sel(tile_type="anchor") - da_emb_in_cluster.sel(
+            tile_type="neighbor"
+        )
+        near_dist = np.sqrt(da_emb_dist ** 2.0).sum(dim="emb_dim")
+        da_emb_in_cluster["near_dist"] = near_dist
+        img_idxs = da_emb_in_cluster.sortby("near_dist", reverse=True).tile_id.values[
+            :n_samples
+        ]
+    else:
+        raise NotImplementedError(sampling_method)
+
+    return img_idxs
+
+
+def _find_leaf_indxs_and_fig_posns(Z, ddata, ax):
+    """
+    Plot a dendrogram into axes `ax` and return for each leaf cluster the
+    item-indecies that belong to that cluster
+    """
+    # find the lowest link
+    y_merges = np.array(ddata["dcoord"])
+    d_max = np.min(y_merges[y_merges > 0.0])
+
+    d2 = Z[:, 2][np.argwhere(Z[:, 2] == d_max)[0][0] - 1]
+
+    T = hc.fcluster(Z, t=d2, criterion="distance")
+    L, M = hc.leaders(Z, T)
+
+    assert set(L) == set(ddata["leaves"])
+
+    # get the actual leaf from the indecies (these were set by providing the
+    # `leaf_label_func` above)
+    leaf_indecies_from_labels = np.array(
+        [int(lab.get_text()) for lab in ax.get_xticklabels()]
+    ).tolist()
+
+    ax.set_xticklabels(np.arange(len(leaf_indecies_from_labels)))
+
+    # work out which leaf each item (image) belongs to
+    mapping = dict(zip(M, L))
+    leaf_mapping = np.array(list(map(lambda i: mapping[i], T)))
+
+    # counts per leaf
+    # [(n, sum(leaf_mapping == n)) for n in L]
+
+    tile_idxs_per_cluster = {}
+    for tile_id, leaf_id in enumerate(leaf_mapping):
+        cluster_id = leaf_indecies_from_labels.index(leaf_id)
+        cluster_tile_idxs = tile_idxs_per_cluster.setdefault(cluster_id, [])
+        cluster_tile_idxs.append(tile_id)
+
+    return tile_idxs_per_cluster
+
+
 def dendrogram(
     da_embeddings,
     n_samples=10,
     n_clusters_max=14,
     sampling_method="random",
     debug=False,
-    ax=None,
     show_legend=False,
     label_clusters=False,
     return_clusters=False,
@@ -90,7 +173,6 @@ def dendrogram(
 
     Additional kwargs will be passed to scipy.cluster.hierarchy.dendrogram
     """
-
     tile_type = None
     if "tile_type" in da_embeddings.coords:
         embeddings_tts = set(da_embeddings.tile_type.values)
@@ -101,7 +183,7 @@ def dendrogram(
             )
         else:
             raise NotImplementedError(embeddings_tts)
-        if not "tile_type" in kwargs:
+        if "tile_type" not in kwargs:
             raise Exception(
                 "You must provide the tile_type when plotting a dendrogram"
                 " from embeddings of triplets"
@@ -115,10 +197,40 @@ def dendrogram(
         )
         tile_type = da_embeddings.tile_type
 
-    if ax is None:
-        fig, ax = plt.subplots(figsize=(14, 3))
-    else:
-        fig = ax.figure
+    fig_margin = 0.4  # [inches]
+    fig_width = 10.0 + 2.0 * fig_margin  # [inches]
+    tile_space = (fig_width - 2.0 * fig_margin) / float(n_clusters_max)
+
+    dendrogram_ny = 2  # in units of tile size
+    dendrogram_height = tile_space * dendrogram_ny
+    tile_samples_height = tile_space * n_samples
+    fig_ny = dendrogram_ny + n_samples * 1
+    # bottom margin will be twice the top to make sure the rendered tiles don't
+    # get clipped off
+    fig_height = dendrogram_height + tile_samples_height + fig_margin * 3.0
+
+    fig = plt.figure(figsize=(fig_width, fig_height))
+    gridspec = fig.add_gridspec(ncols=1, nrows=fig_ny)
+    ax_dendrogram = fig.add_subplot(gridspec[:dendrogram_ny])
+
+    tile_size = 0.9
+    y_offset = tile_size / 2.0 + 0.4 * fig_ny / fig_height  # 0.4 will be in inches
+    if label_clusters:
+        y_offset += 0.2 * fig_ny / fig_height
+    tile_ymax = n_samples + y_offset
+    ax_tiles = fig.add_subplot(gridspec[dendrogram_ny:])
+    ax_tiles.set_ylim(y_offset, tile_ymax)
+
+    if not debug:
+        ax_tiles.axis("off")
+
+    fig.subplots_adjust(
+        left=fig_margin / fig_width,
+        right=1.0 - fig_margin / fig_width,
+        top=1.0 - fig_margin / fig_height,
+        bottom=fig_margin / fig_height,
+        hspace=0.0,
+    )
 
     if "tile_type" in da_embeddings.coords:
         da_clustering = da_embeddings.sel(tile_type=tile_type)
@@ -133,176 +245,110 @@ def dendrogram(
     if color is not None:
         kwargs["link_color_func"] = lambda k: color
 
-    # we want to label the leaf by the index of the leaf node, at least
-    # initially. Below we will change the labels to have the count in each
-    # leaf, but we don't know that number yet
-    leaf_label_func = lambda i: str(i)
+    # we want to inititally use the `leaf_label_func` to label the leaf by the
+    # index of the leaf node so we can retrieve these indecies.
+    # Below we will change the labels to have the count in each leaf, but we
+    # don't know that number yet
+    def leaf_label_func(i):
+        return str(i)
+
     kwargs["leaf_label_func"] = leaf_label_func
 
     ddata = hc.dendrogram(
-        Z=Z, truncate_mode="lastp", p=n_clusters_max, get_leaves=True, **kwargs
+        Z=Z,
+        truncate_mode="lastp",
+        p=n_clusters_max,
+        ax=ax_dendrogram,
+        get_leaves=True,
+        **kwargs
     )
 
-    if debug:
-        for ii in range(len(ddata["icoord"])):
-
-            bl, br = list(zip(ddata["icoord"][ii], ddata["dcoord"][ii]))[
-                0::3
-            ]  # second and third are top left and right corners
-            ax.scatter(*bl, marker="s", label=ii, s=100)
-            ax.scatter(*br, marker="s", label=ii, s=100)
-
-    # find the lowest link
-    y_merges = np.array(ddata["dcoord"])
-    d_max = np.min(y_merges[y_merges > 0.0])
-
-    d2 = Z[:, 2][np.argwhere(Z[:, 2] == d_max)[0][0] - 1]
-
-    if debug:
-        plt.axhline(d_max, linestyle="--", color="grey")
-        ax.legend()
-
-    T = hc.fcluster(Z, t=d2, criterion="distance")
-    L, M = hc.leaders(Z, T)
-
-    assert set(L) == set(ddata["leaves"])
-
-    # getting leaf locations
-    # the order in `L` (leaders) above unfortunately is *not* same as the order
-    # of points in icoord so instead we pick up the order from the actual
-    # labels used
-    bl_pts = np.array(
-        [
-            np.asarray(ddata["icoord"])[:, 0],  # x at bottom-right corner
-            np.asarray(ddata["dcoord"])[:, 0],  # y at bottom-right corner
-        ]
-    )
-    br_pts = np.array(
-        [
-            np.asarray(ddata["icoord"])[:, -1],  # x at bottom-right corner
-            np.asarray(ddata["dcoord"])[:, -1],  # y at bottom-right corner
-        ]
+    tile_idxs_per_cluster = _find_leaf_indxs_and_fig_posns(
+        Z=Z, ddata=ddata, ax=ax_dendrogram
     )
 
-    leaf_pts = np.append(bl_pts, br_pts, axis=1)
-    # remove pts where y != 0 as these mark joins within the diagram and don't
-    # connect to the edge
-    leaf_pts = leaf_pts[:, ~(leaf_pts[1] > 0)]
-    # sort by x-coordinate for leaf labels, so that the positions are in the
-    # same order as the axis labels
-    leaf_pts = leaf_pts[:, leaf_pts[0, :].argsort()]
-    # get the actual leaf from the indecies (these were set by providing the
-    # `leaf_label_func` above)
-    leaf_indecies_from_labels = np.array(
-        [int(lab.get_text()) for lab in ax.get_xticklabels()]
+    # the dendrogram plot uses the below transform for how to position the leaf
+    # cluster points
+
+    def xposn2clusterid(x):
+        return (x - 5) / 10
+
+    def clusterid2xposn(x):
+        return x * 10 + 5
+
+    # create a secondary axes on the dendrogram axes which is scaled so that
+    # the x-positions match the cluster indecies (0, 1, ... n_max_clusters-1)
+    # we can then join this with the axes below where we will render the tiles
+    # and the x-positioning becomes much easier
+    ax_tiles.set_aspect(1.0)
+    secax = ax_dendrogram.secondary_xaxis(
+        "bottom", functions=(xposn2clusterid, clusterid2xposn)
     )
-    # create mapping from the leaf indecies to the (x,y)-points in the
-    # dendrogram where these leaves terminate
-    leaf_pts_mapping = dict(zip(leaf_indecies_from_labels, leaf_pts.T))
+    secax.set_xticklabels([])
+    secax.set_xticks([])
+    ax_tiles.get_shared_x_axes().join(secax, ax_tiles)
 
-    # work out which leaf each item (image) belongs to
-    mapping = dict(zip(M, L))
-    leaf_mapping = np.array(list(map(lambda i: mapping[i], T)))
+    N_clusters = len(tile_idxs_per_cluster)
 
-    N_leaves = len(np.unique(leaf_mapping))
+    for cluster_id in np.arange(N_clusters):
+        img_idxs_in_cluster = tile_idxs_per_cluster[cluster_id]
 
-    # counts per leaf
-    # [(n, sum(leaf_mapping == n)) for n in L]
-
-    w_pad = 0.02
-    size = (3.6 - (n_clusters_max - 1.0) * w_pad) / float(n_clusters_max)
-    y_offset = 1.4
-    if label_clusters:
-        y_offset += 0.2
-
-    for lid, leaf_id in enumerate(ddata["leaves"]):
-        img_idxs_in_cluster = da_clustering.tile_id.values[
-            leaf_mapping == leaf_id
-        ].astype(int)
-        if sampling_method == "random":
-            try:
-                img_idxs = np.random.choice(
-                    img_idxs_in_cluster, size=n_samples, replace=False
-                )
-            except ValueError:
-                img_idxs = img_idxs_in_cluster
-        elif sampling_method == "center_dist":
-            emb_in_cluster = da_clustering.sel(tile_id=img_idxs_in_cluster)
-            d_emb = emb_in_cluster.mean(dim="tile_id") - emb_in_cluster
-            center_dist = np.sqrt(d_emb ** 2.0).sum(dim="emb_dim")
-            emb_in_cluster["dist_to_center"] = center_dist
-            img_idxs = emb_in_cluster.sortby("dist_to_center").tile_id.values[
-                :n_samples
-            ]
-        elif sampling_method in ["best_triplets", "worst_triplets"]:
-            if "tile_type" not in da_embeddings.coords:
-                raise Exception(
-                    "Selection method based on triplets can only be used when"
-                    " passing in embeddings for triplets"
-                )
-            da_emb_in_cluster = da_embeddings.sel(tile_id=img_idxs_in_cluster)
-            da_emb_dist = da_emb_in_cluster.sel(
-                tile_type="anchor"
-            ) - da_emb_in_cluster.sel(tile_type="neighbor")
-            near_dist = np.sqrt(da_emb_dist ** 2.0).sum(dim="emb_dim")
-            da_emb_in_cluster["near_dist"] = near_dist
-            img_idxs_all = da_emb_in_cluster.sortby("near_dist").tile_id.values
-            if sampling_method == "best_triplets":
-                img_idxs = img_idxs_all[:n_samples]
-            else:
-                img_idxs = img_idxs_all[::-1][:n_samples]
-        elif sampling_method == "worst_triplets":
-            da_emb_in_cluster = da_embeddings.sel(tile_id=img_idxs_in_cluster)
-            da_emb_dist = da_emb_in_cluster.sel(
-                tile_type="anchor"
-            ) - da_emb_in_cluster.sel(tile_type="neighbor")
-            near_dist = np.sqrt(da_emb_dist ** 2.0).sum(dim="emb_dim")
-            da_emb_in_cluster["near_dist"] = near_dist
-            img_idxs = da_emb_in_cluster.sortby(
-                "near_dist", reverse=True
-            ).tile_id.values[:n_samples]
-        else:
-            raise NotImplementedError(sampling_method)
+        img_idxs = _find_tile_indecies(
+            img_idxs_in_cluster=img_idxs_in_cluster,
+            n_samples=n_samples,
+            sampling_method=sampling_method,
+            da_clustering=da_clustering,
+            da_embeddings=da_embeddings,
+        )
 
         def transform(coord):
-            axis_to_data = fig.transFigure + ax.transData.inverted()
+            axis_to_data = fig.transFigure + ax_dendrogram.transData.inverted()
+            axis_to_data = ax_dendrogram.transData.inverted()
             data_to_axis = axis_to_data.inverted()
             return data_to_axis.transform(coord)
 
-        leaf_xy = leaf_pts_mapping[leaf_id]
-        xp, yh = transform(leaf_xy)
+        leaf_xy = [cluster_id, tile_ymax]
+        tile_start_xy = [cluster_id, n_samples]
 
         if show_legend:
-            ax.scatter(*leaf_xy, marker="s", label=lid, s=100)
+            ax_tiles.scatter(*leaf_xy, marker="s", label=cluster_id, s=100)
 
         for n, img_idx in enumerate(img_idxs):
             img = _get_tile_image(
                 tile_dataset=tile_dataset, i=img_idx, tile_type=tile_type
             )
 
-            ax1 = fig.add_axes(
-                [xp - 0.5 * size, yh - size * 1.1 * (n + y_offset), size, size]
+            xp, yh = tile_start_xy
+            ax_tile = ax_tiles.inset_axes(
+                [
+                    xp - 0.5 * tile_size,
+                    yh - 1.0 * n - 0.5 * tile_size,
+                    tile_size,
+                    tile_size,
+                ],
+                transform=ax_tiles.transData,
             )
-            ax1.set_aspect(1)
-            ax1.axison = False
-            ax1.imshow(img)
 
-    ax.set_xticklabels(
-        _fix_labels(ax=ax, leaf_mapping=leaf_mapping, label_clusters=label_clusters)
+            ax_tile.set_aspect(1)
+            ax_tile.axison = False
+            ax_tile.imshow(img)
+
+    ax_dendrogram.set_xticklabels(
+        _fix_labels(
+            ax=ax_dendrogram,
+            tile_idxs_per_cluster=tile_idxs_per_cluster,
+            label_clusters=label_clusters,
+        )
     )
 
     if show_legend:
-        ax.legend()
+        ax_tiles.legend()
 
     if return_clusters:
-        # instead of returning the actual indecies of the leaves here (as were
-        # used above) we remap so that they run from 0...N_leaves
-        leaf_idxs_remapped = np.array(
-            [list(leaf_indecies_from_labels).index(i) for i in leaf_mapping]
-        )
+        cluster_idxs = list(tile_idxs_per_cluster.keys())
         if not label_clusters:
-            return ax, leaf_idxs_remapped
+            return fig, cluster_idxs
         else:
-            return ax, _make_letter_labels(N_leaves)[leaf_idxs_remapped]
+            return fig, _make_letter_labels(N_clusters)[cluster_idxs]
     else:
-        return ax
+        return fig

--- a/convml_tt/trainer_logging.py
+++ b/convml_tt/trainer_logging.py
@@ -22,10 +22,11 @@ def make_dendrogram_logger(datamodule):
         except FileNotFoundError:
             dataset = datamodule.get_dataset(stage="fit")
         da_embeddings = get_embeddings(tile_dataset=dataset, model=model)
-        ax = dendrogram(
-            da_embeddings=da_embeddings, tile_type="anchor", sampling="best_triplets"
+        fig = dendrogram(
+            da_embeddings=da_embeddings,
+            tile_type="anchor",
+            sampling_method="best_triplets",
         )
-        fig = ax.figure
-        wandb.log({f"{stage}_dendrogram": fig})
+        wandb.log({f"{stage}_dendrogram": wandb.Image(fig)})
 
     return _logger


### PR DESCRIPTION
Dendrogram plot code has been refactored so that all components of plot
are inside the figure's [0:1]x[0:1] extent. This ensure that tiles are
clipped off when uploading to W&B. The refactor also makes it easier in
future to put dendrogram annotations on other kinds of plots (for
example confusion matrices).