### PR TITLE
Fix for xarray bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## [Unreleased](https://github.com/convml/convml_tt/tree/HEAD)
 
-[Full Changelog](https://github.com/convml/convml_tt/compare/v0.10.0...HEAD)
+[Full Changelog](https://github.com/convml/convml_tt/compare/v0.10.1...HEAD)
+
+
+## [v0.10.1](https://github.com/convml/convml_tt/tree/v0.10.1)
+
+[Full Changelog](https://github.com/convml/convml_tt/compare/v0.10.0...v0.10.1)
+
+*bugfixes*
+
+- Fix for xarray bug which arised with call in
+  `utils.interpretation.rectpred.plot.make_rgb`
+  [\#51](https://github.com/convml/convml_tt/pull/51)
 
 
 ## [v0.10.0](https://github.com/convml/convml_tt/tree/v0.10.0)

--- a/convml_tt/interpretation/rectpred/plot.py
+++ b/convml_tt/interpretation/rectpred/plot.py
@@ -41,7 +41,7 @@ def make_rgb(da, alpha=0.5, **coord_components):
     )
 
     def _make_component(da_):
-        if da_.rgba == 3:
+        if da_.rgba.data == 3:
             return alpha * np.ones_like(da_)
         else:
             return scale(da.sel({v_dim: dim_idxs[da_.rgba.item()]}).values)


### PR DESCRIPTION
On google colab the `xr.DataArray([0]) == 3` was raising an exception
due to the absolute import of xarray in `xarray.core.variable`. By
extracting the data in `make_rgb` we avoid the comparison that lead to
this exception being raised.