### PR TITLE
Rect annotated scatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [Full Changelog](https://github.com/convml/convml_tt/compare/v0.10.1...HEAD)
 
+*new features*
+
+- Annotated scatterplots now work for `data.dataset.MovingWindowImageTilingDataset`s
+  [\#52](https://github.com/convml/convml_tt/pull/52)
+
 
 ## [v0.10.1](https://github.com/convml/convml_tt/tree/v0.10.1)
 

--- a/convml_tt/interpretation/plots/annotated_scatter_plot.py
+++ b/convml_tt/interpretation/plots/annotated_scatter_plot.py
@@ -92,6 +92,19 @@ def annotated_scatter_plot(
             "`x` or `y`. Either set these or provide a `tile_dataset`"
         )
 
+    if x.shape != y.shape:
+        raise Exception(f"x and y don't have the same shape ({x.shape} != {y.shape})")
+    elif x.dims != y.dims:
+        raise Exception(
+            f"x and y don't have the same dimensions ({x.dims} != {y.dims})"
+        )
+    elif len(x.shape) != 1:
+        # looks like the embeddings provided have been unstacked (for example
+        # they're representing embeddings in a 2D domain). Let's see if we can
+        # stack them into a single 1D array
+        x = x.stack(sample=x.dims)
+        y = y.stack(sample=y.dims)
+
     def _is_array(v):
         return isinstance(v, np.ndarray) or (type(v) == list and type(v[0]) == int)
 

--- a/convml_tt/interpretation/rectpred/sample.py
+++ b/convml_tt/interpretation/rectpred/sample.py
@@ -30,9 +30,7 @@ def make_plot(model, image_path, N_tile, prediction_batch_size=128):
     tile_dataset = MovingWindowImageTilingDataset(
         img=img, transform=transforms, step=step, N_tile=N_tile
     )
-    da_emb = make_sliding_tile_model_predictions(
-        tile_dataset=tile_dataset, model=model
-    )
+    da_emb = make_sliding_tile_model_predictions(tile_dataset=tile_dataset, model=model)
 
     da_emb_pca = apply_transform(da_emb, "pca")
 

--- a/convml_tt/interpretation/rectpred/transform.py
+++ b/convml_tt/interpretation/rectpred/transform.py
@@ -132,6 +132,11 @@ def apply_transform(
         s = ",".join([f"{k}={v}" for (k, v) in kwargs])
         da_transformed.attrs["transform_extra_args"] = s
 
+    # explicitly copy over coords that we want to retain
+    for c in ["image_path", "src_data_path"]:
+        if c in da:
+            da_transformed[c] = da[c]
+
     if return_model:
         return da_transformed, model
     else:

--- a/convml_tt/utils.py
+++ b/convml_tt/utils.py
@@ -90,7 +90,16 @@ def make_sliding_tile_model_predictions(
     j_img_tile_center = (j_img_tile + 0.5 * tile_dataset.nyt).astype(int)
     da_emb["i0"] = ("tile_id"), i_img_tile_center
     da_emb["j0"] = ("tile_id"), j_img_tile_center
+
+    # because we want to retain the tile id for later we make a copy here (the
+    # coordinate itself will disappear when we unstack). Need to take the
+    # `values` otherwise the unstacking fails (because xarray is confused about
+    # the copy of the coordinate)
+    da_emb["tile_id_copy"] = ("tile_id"), da_emb.tile_id.values
+
     da_emb = da_emb.set_index(tile_id=("i0", "j0")).unstack("tile_id")
+
+    da_emb = da_emb.rename(tile_id_copy="tile_id")
 
     da_emb.attrs["tile_nx"] = tile_dataset.nxt
     da_emb.attrs["tile_ny"] = tile_dataset.nyt

--- a/tests/test_rectpred.py
+++ b/tests/test_rectpred.py
@@ -10,6 +10,7 @@ from convml_tt.data.dataset import MovingWindowImageTilingDataset
 from convml_tt.data.transforms import get_transforms as get_model_transforms
 from convml_tt.interpretation.rectpred.plot import make_rgb
 from convml_tt.interpretation.rectpred.transform import apply_transform
+from convml_tt.interpretation.plots import annotated_scatter_plot
 
 DOC_PATH = Path(__file__).parent.parent / "doc"
 RECTPRED_IMG_EXAMPLE_PATH = DOC_PATH / "goes16_202002051400.png"
@@ -47,6 +48,13 @@ def test_rectpred_sliding_window_inference():
     assert da_emb_rect.emb_dim.count() == model.n_embedding_dims
     assert da_emb_rect.i0.count() == nxt
     assert da_emb_rect.j0.count() == nyt
+
+    # try creating an annotated scatter with the embedding
+    da_x = da_emb_rect.sel(emb_dim=0)
+    da_y = da_emb_rect.sel(emb_dim=0)
+    annotated_scatter_plot(
+        x=da_x, y=da_y, points=5, tile_dataset=tile_dataset, autopos_method=None
+    )
 
 
 def test_apply_transform_rect():


### PR DESCRIPTION
add support for producing annotated scatter plots from tile datasets produced from sliding window predictions