### PR TITLE
Enable inference with GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Full Changelog](https://github.com/convml/convml_tt/compare/v0.10.1...HEAD)
 
+*new features*
+
+- `utils.get_embeddings` now uses GPU for producing the embeddings if one is
+  available, drastically speeding up inference time.
+  [\#53](https://github.com/convml/convml_tt/pull/53)
+
 
 ## [v0.10.1](https://github.com/convml/convml_tt/tree/v0.10.1)
 

--- a/convml_tt/data/dataset.py
+++ b/convml_tt/data/dataset.py
@@ -95,6 +95,15 @@ class ImageTripletDataset(_ImageDatasetBase):
         if set(n_tiles.values()) == {0}:
             raise FileNotFoundError(f"No {stage} data was found in `{data_dir}`")
 
+    def make_singlet_dataset(self, tile_type):
+        """Produce an ImageSingletDataset for a particular tile type"""
+        return ImageSingletDataset(
+            data_dir=self.data_dir,
+            tile_type=tile_type,
+            stage=self.stage,
+            transform=self.transform,
+        )
+
     def get_image(self, index, tile_type):
         image_file_path = self.file_paths[tile_type][index]
         return self._read_image(image_file_path)

--- a/convml_tt/utils.py
+++ b/convml_tt/utils.py
@@ -48,7 +48,7 @@ def get_embeddings(
         gpus = 1
     else:
         gpus = 0
-    trainer = pl.Trainer()
+    trainer = pl.Trainer(gpus=gpus)
 
     def apply_model(x):
         return trainer.predict(model=model, dataloaders=[tile_dataloader])[0]

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytorch_lightning as pl
 import torch
 from pytorch_lightning.callbacks import LearningRateMonitor
+import pytest
 
 from convml_tt.data.dataset import ImageSingletDataset, TileType
 from convml_tt.data.examples import (
@@ -20,8 +21,14 @@ from convml_tt.trainer_onecycle import OneCycleTrainer
 from convml_tt.utils import get_embeddings
 
 
+if torch.cuda.is_available():
+    N_GPUS = 1
+else:
+    N_GPUS = 0
+
+
 def test_train_new():
-    trainer = pl.Trainer(max_epochs=5)
+    trainer = pl.Trainer(max_epochs=5, gpus=N_GPUS)
     arch = "resnet18"
     model = TripletTrainerModel(pretrained=False, base_arch=arch)
     data_path = fetch_example_dataset(dataset=ExampleData.TINY10)
@@ -32,7 +39,7 @@ def test_train_new():
 
 
 def test_train_new_anti_aliased():
-    trainer = pl.Trainer(max_epochs=5)
+    trainer = pl.Trainer(max_epochs=5, gpus=N_GPUS)
     arch = "resnet18"
     model = TripletTrainerModel(
         pretrained=False, base_arch=arch, anti_aliased_backbone=True
@@ -45,7 +52,7 @@ def test_train_new_anti_aliased():
 
 
 def test_train_new_with_preloading():
-    trainer = pl.Trainer(max_epochs=5)
+    trainer = pl.Trainer(max_epochs=5, gpus=N_GPUS)
     arch = "resnet18"
     model = TripletTrainerModel(pretrained=False, base_arch=arch)
     data_path = fetch_example_dataset(dataset=ExampleData.TINY10)
@@ -56,7 +63,7 @@ def test_train_new_with_preloading():
 
 
 def test_finetune_pretrained():
-    trainer = pl.Trainer(max_epochs=5, callbacks=[HeadFineTuner()])
+    trainer = pl.Trainer(max_epochs=5, callbacks=[HeadFineTuner()], gpus=N_GPUS)
     arch = "resnet18"
     model = TripletTrainerModel(pretrained=True, base_arch=arch)
     data_path = fetch_example_dataset(dataset=ExampleData.TINY10)
@@ -121,7 +128,7 @@ def test_load_from_weights():
 
 def test_train_new_onecycle():
     lr_monitor = LearningRateMonitor(logging_interval="step")
-    trainer = OneCycleTrainer(max_epochs=5, callbacks=[lr_monitor])
+    trainer = OneCycleTrainer(max_epochs=5, callbacks=[lr_monitor], gpus=N_GPUS)
     arch = "resnet18"
     model = TripletTrainerModel(pretrained=False, base_arch=arch)
     data_path = fetch_example_dataset(dataset=ExampleData.TINY10)


### PR DESCRIPTION
Change `utils.get_embeddings` to use a GPU if one is available. This
drastically decreases inference time. Also enable testing with GPU if
one is available.