### PR TITLE
Fix bug in dendrogram on filtered emb vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
   annotations staying in place and keep a fixed size
   [\#58](https://github.com/convml/convml_tt/pull/59)
 
+*bugfixes*
+
+- Fix bug in dendrogram plot where wrong tiles were shown when creating a
+  dendrogram from a data-array of embedding vectors that have been filtered (so
+  that the tile ids don't just from 0, 1, 2 etc)
+  [\#67](https://github.com/convml/convml_tt/pull/67)
+
 *general improvements*
 
 - Option to skip tile triplets with missing tiles when creating `TripletDataset`

--- a/convml_tt/interpretation/plots/dendrogram.py
+++ b/convml_tt/interpretation/plots/dendrogram.py
@@ -262,9 +262,15 @@ def dendrogram(
         **kwargs
     )
 
-    tile_idxs_per_cluster = _find_leaf_indxs_and_fig_posns(
+    # the indecies returned when finding the leaf indecies below number from
+    # zero, but we want the actual tile IDs and so need to map into those here
+    idxs_per_cluster = _find_leaf_indxs_and_fig_posns(
         Z=Z, ddata=ddata, ax=ax_dendrogram
     )
+
+    tile_idxs_per_cluster = {}
+    for c_id, idxs in idxs_per_cluster.items():
+        tile_idxs_per_cluster[c_id] = da_embeddings.isel(tile_id=idxs).tile_id.values
 
     # the dendrogram plot uses the below transform for how to position the leaf
     # cluster points


### PR DESCRIPTION
Previously the tile id was calculated incorreclty inside the dendrogram
plotting function so that when passing in data-array with embedding
vectors where a subset of tiles had been selected the wrong tiles would
be shown.