### PR TITLE
Make fastai v1 weights loader work for GPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 
 *maintenance*
 
+- Ensure loading of fastai v1 models (from weights) also works when we have a
+  GPU available
+  [\#68](https://github.com/convml/convml_tt/pull/68)
+
 - Add CI action to automatically publish tagged releases on pypi
   [\#63](https://github.com/convml/convml_tt/pull/63)
 

--- a/convml_tt/external/fastai1_weights_loader.py
+++ b/convml_tt/external/fastai1_weights_loader.py
@@ -1,3 +1,4 @@
+import hashlib
 import warnings
 
 import torch
@@ -23,11 +24,13 @@ def model_from_saved_weights(path):
     pytorch-lightning's `trainer.save_checkpoint(...)` and
     `TripletTrainerModel.load_checkpoint(...)` should be used.
     """
+    dev = torch.device("cpu")
+
     # pytorch may issue some warnings here, but we just want to load the
     # model anyway, so hide the wwarnings for now
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        loaded_encoder = torch.load(path)
+        loaded_encoder = torch.load(path).to(dev)
     batch_size = 5
     nx = ny = 256
     # the first layer is the conv1d, find out how many input channels it has
@@ -38,14 +41,21 @@ def model_from_saved_weights(path):
     # weren't part of pytorch 1.0.1 that the old model was created in). We also
     # introduce a scaling layer because the fastai v1 network created values
     # that we're very small
+    model_hash = hashlib.md5(open(path, "rb").read()).hexdigest()
+    if model_hash == "d23b8370173082774052974f4729733e":
+        scaling = 1.0e3
+        scaling = 1.0
+    else:
+        scaling = 1.0e0
+
     head = loaded_encoder[-1]
     new_head = nn.Sequential(
-        AdaptiveConcatPool2d(size=1), nn.Flatten(), *head, ScalingLayer(1.0e3)
+        AdaptiveConcatPool2d(size=1), nn.Flatten(), *head, ScalingLayer(scaling)
     )
     # we use the backbone as-is
     backbone = loaded_encoder[:-1]
 
-    rand_batch = torch.rand((batch_size, n_input_channels, nx, ny))
+    rand_batch = torch.rand((batch_size, n_input_channels, nx, ny)).to(dev)
     try:
         # check that the model accepts data shaped like a batch and produces the expected output
         # all we know is the weights, so this model won't be possible to train further


### PR DESCRIPTION
Change weights loader to ensure checks inside of function do
calculations on the CPU rather than GPU, using a mix was causing pytorch
to raise an exception. Also, only apply scaling with `fixed_norm_2nd`
model, others trained since don't need scaling.